### PR TITLE
fix(ci): update dependency versions

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Install terraform-docs
         id: install-terraform-docs
         run: |
-          curl -Lo ./terraform-docs.tar.gz https://github.com/terraform-docs/terraform-docs/releases/download/v0.16.0/terraform-docs-v0.16.0-$(uname)-amd64.tar.gz
+          curl -Lo ./terraform-docs.tar.gz https://github.com/terraform-docs/terraform-docs/releases/download/v0.17.0/terraform-docs-v0.17.0-$(uname)-amd64.tar.gz
           tar -xzf terraform-docs.tar.gz
           chmod +x terraform-docs
           sudo mv terraform-docs /usr/local/bin/terraform-docs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.6.0
     hooks:
       - id: trailing-whitespace
         args:
@@ -11,7 +11,7 @@ repos:
       - id: check-added-large-files
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.77.1
+    rev: v1.89.1
     hooks:
       - id: terraform_fmt
         args:
@@ -24,11 +24,11 @@ repos:
           - --args=--config=__GIT_WORKING_DIR__/.tflint.hcl
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.21.0
+    rev: 0.28.3
     hooks:
       - id: check-github-workflows
 
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.16.1
+    rev: v8.18.2
     hooks:
       - id: gitleaks

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,10 +1,12 @@
 plugin "terraform" {
   enabled = true
   preset  = "recommended"
+  version = "0.7.0"
+  source  = "github.com/terraform-linters/tflint-ruleset-terraform"
 }
 
 plugin "aws" {
     enabled = true
-    version = "0.21.2"
+    version = "0.31.0"
     source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }


### PR DESCRIPTION
Update dependency versions for terraform-docs in GitHub Actions pre-commit workflow, TFLint plugins, pre-commit hooks, pre-commit Terraform, pre-commit Check JSON Schema, and pre-commit Gitleaks.